### PR TITLE
Fixed revoke command.

### DIFF
--- a/044_postgres/15_users/README.md
+++ b/044_postgres/15_users/README.md
@@ -23,7 +23,7 @@ GRANT ALL PRIVILEGES ON DATABASE company to james;
 
 ## revoke privileges
 ```
-REVOKE ALL PRIVILEGES ON DATABASE company to james;
+REVOKE ALL PRIVILEGES ON DATABASE company from james;
 ```
 
 ## alter


### PR DESCRIPTION
Hi,

Fixed syntax for "REVOKE ALL PRIVILEGES" command.
As you said it should be "from" instead of "to".

Regards,
Dmytro