### PR TITLE
cleaned getUser function and fixed issue with generating new uuid

### DIFF
--- a/030_sessions/03_signup/main.go
+++ b/030_sessions/03_signup/main.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"github.com/satori/go.uuid"
 	"html/template"
 	"net/http"
+
+	uuid "github.com/satori/go.uuid"
 )
 
 type user struct {
@@ -30,12 +31,12 @@ func main() {
 }
 
 func index(w http.ResponseWriter, req *http.Request) {
-	u := getUser(w, req)
+	u := getUser(req)
 	tpl.ExecuteTemplate(w, "index.gohtml", u)
 }
 
 func bar(w http.ResponseWriter, req *http.Request) {
-	u := getUser(w, req)
+	u := getUser(req)
 	if !alreadyLoggedIn(req) {
 		http.Redirect(w, req, "/", http.StatusSeeOther)
 		return

--- a/030_sessions/03_signup/session.go
+++ b/030_sessions/03_signup/session.go
@@ -2,26 +2,18 @@ package main
 
 import (
 	"net/http"
-
-	"github.com/satori/go.uuid"
 )
 
-func getUser(w http.ResponseWriter, req *http.Request) user {
+func getUser(req *http.Request) user {
+	var u user
+
 	// get cookie
 	c, err := req.Cookie("session")
 	if err != nil {
-		sID, _ := uuid.NewV4()
-		c = &http.Cookie{
-			Name:  "session",
-			Value: sID.String(),
-		}
-
+		return u
 	}
-	//Next line may not be required, commenting it
-	// http.SetCookie(w, c)
 
 	// if the user exists already, get user
-	var u user
 	if un, ok := dbSessions[c.Value]; ok {
 		u = dbUsers[un]
 	}


### PR DESCRIPTION
There is a "bug" in getUser function. This function should check whether the user exists or not and return the value of type user. If the user doesn't exist, we are creating new cookie with new uuid and testing whether user with such uuid exists in dbSessions/dbUsers or not. This is wrong, if the cookie doesn't exist then we should just return. Generating new uuid value and then searching for user in dbSessions/dbUsers based on in is equivalent to searching for uuid collision because such user can't exist since we have generated new uuid value just now without any logic that would associate it with a particular user.

There is also no need to pass http.ResponseWriter argument to that function, since this function's purpose is just to get a user for additional processing, not to generate an HTTP response. 

I have removed that part that generates the cookie, removed the first parameter (w http.ResponseWriter) and updated function calls to reflect this change (removed passing w to getUser function)