### PR TITLE
make new version work

### DIFF
--- a/026_appengine-deploy/01/app.yaml
+++ b/026_appengine-deploy/01/app.yaml
@@ -1,8 +1,2 @@
-application: temp-145415
-version: 1
-runtime: go
-api_version: go1
-
-handlers:
-- url: /.*
-  script: _go_app
+# tell Google that we want to run Go 1.13
+runtime: go113


### PR DESCRIPTION
- specify go version in app.yaml
- most other declarations in app.yaml now invalid
- pass project name and version as flags in the gcloud command