### PR TITLE
fix panic in case of empty commands GET and DEL

### DIFF
--- a/015_understanding-TCP-servers/07_tcp-apps/02_memory-database/main.go
+++ b/015_understanding-TCP-servers/07_tcp-apps/02_memory-database/main.go
@@ -51,6 +51,10 @@ func handle(conn net.Conn) {
 		}
 		switch fs[0] {
 		case "GET":
+			if len(fs) != 2 {
+				fmt.Fprintln(conn, "EXPECTED KEY\r\n")
+				continue
+			}
 			k := fs[1]
 			v := data[k]
 			fmt.Fprintf(conn, "%s\r\n", v)
@@ -63,6 +67,10 @@ func handle(conn net.Conn) {
 			v := fs[2]
 			data[k] = v
 		case "DEL":
+			if len(fs) != 2 {
+				fmt.Fprintln(conn, "EXPECTED KEY\r\n")
+				continue
+			}
 			k := fs[1]
 			delete(data, k)
 		default:


### PR DESCRIPTION
Added check of array length for **GET** and **DEL** commands to avoid panic
**panic: runtime error: index out of range [1] with length 1**
