### PR TITLE
Add starting-files directory path

### DIFF
--- a/024_hands-on/06_solution/main.go
+++ b/024_hands-on/06_solution/main.go
@@ -9,11 +9,11 @@ import (
 var tpl *template.Template
 
 func init() {
-	tpl = template.Must(template.ParseFiles("templates/index.gohtml"))
+	tpl = template.Must(template.ParseFiles("./starting-files/templates/index.gohtml"))
 }
 
 func main() {
-	fs := http.FileServer(http.Dir("public"))
+	fs := http.FileServer(http.Dir("./starting-files/public"))
 	http.Handle("/pics/", fs)
 	http.HandleFunc("/", dogs)
 	http.ListenAndServe(":8080", nil)


### PR DESCRIPTION
Currently, the call to template.Must fails as the starting files directory path is missing from the relative path templates/index.gohtml (line 12). Additionally, the images will not serve as the fs references public and not ./starting-files/public.